### PR TITLE
Merge the new and legacy documentation into /features/proxy

### DIFF
--- a/content/features/proxy/_index.md
+++ b/content/features/proxy/_index.md
@@ -1,5 +1,5 @@
 +++
-title = 'Builtin Proxy'
+title = 'Built-in proxy'
 date = 2024-09-01T09:31:55-07:00
 weight = 1
 next = '/features/proxy/quickstart/'

--- a/content/features/proxy/arch.md
+++ b/content/features/proxy/arch.md
@@ -1,7 +1,12 @@
 +++
-title = 'Deployment Architectures'
+title = 'Deployment architectures'
 date = 2024-09-01T09:10:49-07:00
+weight = 60
 +++
+
+This page describes the workings of the Memcached built-in proxy in detail.
+
+For a general overview of the built-in proxy, see [Built-in proxy]({{<proxy_base_path>}}).
 
 ## Client connections and workers
 

--- a/content/features/proxy/configure.md
+++ b/content/features/proxy/configure.md
@@ -5,7 +5,7 @@ weight = 30
 
 This page is about configuring the Memcached built-in proxy.
 
-For a general overview of the proxy, see [Proxy]({{<legacy_proxy_base_path>}}). For a hands-on tutorial that guides you through compiling and running the proxy with a simple configuration, see [Built-in Proxy Quickstart]({{<proxy_base_path>}}quickstart).
+For a general overview of the proxy, see [Built-in proxy]({{<proxy_base_path>}}). For a hands-on tutorial that guides you through compiling and running the proxy with a simple configuration, see [Built-in Proxy Quickstart]({{<proxy_base_path>}}quickstart).
 
 ## Before you begin {#prereqs}
 

--- a/content/features/proxy/examples.md
+++ b/content/features/proxy/examples.md
@@ -1,7 +1,10 @@
 +++
-title = 'Usage Examples'
+title = 'Usage examples'
 date = 2024-09-01T09:08:32-07:00
+weight = 50
 +++
+
+This page provides illustraed examples of ways that you can create load-balanced, multiple-node cacheing systems using the Memcached built-in proxy. For a general overview of the built-in proxy, see [Built-in proxy]({{<proxy_base_path>}}).
 
 The memcached proxy is a flexible and lightweight system with few
 dependencies. Any memcached binary can be a proxy, a cache server, or both.
@@ -188,8 +191,6 @@ with a local sidecar (high bandwidth) and some might use a centralized pool
 Generally the overhead of local connections is low, but this must be verified
 because "container systems" can add significant overhead.
 
----
-
 ## Cache Layering Proxy
 
 ```mermaid
@@ -238,21 +239,3 @@ memcached pool.
 
 - Configuration of pools needs to be managed in two places (application
   clients, memcached proxies)
-
----
-
-# Use Case Examples
-
-## Simplifying and Unifying Cache Clients
-
-## Distributing data by usage
-
-## Best effort data redundancy
-
-## Transparent upgrades
-
-## Transparent pool resizing
-
-## Protocol translation
-
-

--- a/content/features/proxy/faq.md
+++ b/content/features/proxy/faq.md
@@ -1,0 +1,65 @@
++++
+title = 'Frequently asked questions'
+weight = 99
++++
+
+For a general overview of the built-in proxy, see [Built-in proxy]({{<proxy_base_path>}}).
+
+## Why Lua?
+
+I thought ya'll could use a break from YAML :) We use Lua and its
+extensibility like glue: nearly everyone has different methods of managing
+their configuration, and in most cases a simple lua script would be able to
+parse output from such services or talk to them directly. A handful of for
+loops and object reuses can remove tens of thousands of lines of generated
+configuration.
+
+For route handling our usage of Lua is more bold, but again it's simply glue.
+Configurations for routes will tend to be wide but shallow: just a couple
+small function calls based on the contents of the request, and then the
+request is handed back off to the C side. Object methods written in C further
+avoid copying strings/data to/from Lua for common operations.
+
+Since the proxy integrates with memcached's existing systems, we can (over
+time) ensure all large memory allocations are handled outside of Lua. The rest
+of the tiny allocations, if any, are tied to a coroutine and released
+immediately after the (typically under a millisecond) request/response.
+
+## Why not LuaJIT?
+
+For half the answer to this, please see [Why lua?](#why-lua) - for loading
+configuration the performance difference isn't going to matter much. For route
+handling very little work is done from Lua, which will be reduced or removed
+as development continues.
+
+When development started LuaJIT had a much more rocky status. Also Lua 5.4 has
+a good number of language and performance improvements on its own.
+
+## Why not use a mesh router?
+
+Memcached's proxy is not intended to replace a mesh router; its scope is much
+smaller and more performance focused. A mesh router may be highly configurable,
+with broad support, but will be very slow. Caching services (and in this case
+a caching proxy) can be used to restore performance to a service migrated to a
+mesh router; for cost or practicality reasons.
+
+Many data queries don't or shouldn't go through a mesh router anyway. If you
+want to speed up access to data storage from an application implemented as an
+endpoint on a mesh router, a caching service is what sits behind that
+endpoint but before its actual data storage.
+
+## What happens to in-flight requests on config reload?
+
+When the configuration is reloaded, `mcp_config_routes` gets called again.
+During this process routes are assembled into functions and `mcp.attach()` is
+called with these top level hooks. Any time a request comes in these top level
+hooks are checked for their associated function.
+
+This means once a request fires off its hook, it is immune from configuration
+changes until it completes. Any new request coming in will see what's
+presently configured in a hook and get the new code even as older requests are
+being processed.
+
+This does mean you have to be careful with using global variables in Lua: we
+suggest the use of function closures for routes to avoid configurations
+clashing.

--- a/content/features/proxy/install.md
+++ b/content/features/proxy/install.md
@@ -8,7 +8,7 @@ The Memcached built-in proxy is available only if you activate a specific config
 * Build and install Memcached with its proxy features enabled.
 * Download the Lua library that the proxy requires for common tasks.
 
-For a general overview of the proxy, see [Proxy]({{<legacy_proxy_base_path>}}). For a hands-on tutorial that guides you through compiling and running the proxy with a simple configuration, see [Built-in Proxy Quickstart]({{<proxy_base_path>}}quickstart).
+For a general overview of the proxy, see [Built-in proxy]({{<proxy_base_path>}}). For a hands-on tutorial that guides you through compiling and running the proxy with a simple configuration, see [Built-in Proxy Quickstart]({{<proxy_base_path>}}quickstart).
 
 ## Before you begin {#prereqs}
 

--- a/content/features/proxy/quickstart.md
+++ b/content/features/proxy/quickstart.md
@@ -11,7 +11,7 @@ This page helps you get familiar with the Memcached built-in proxy by guiding yo
 * Set up a minimal proxy configuration file that lets the proxy use two Memcached servers as its backend.
 * Run this proxy-based Memcached architecture, and observe the proxy at work by connecting to it and querying it.
 
-For detailed documentation about the Memcached built-in proxy, see [Proxy](({{<legacy_proxy_base_path>}})).
+For a general overview of the Memcached built-in proxy, see [Built-in proxy]({{<proxy_base_path>}}).
 
 ## Before you begin
 

--- a/content/features/proxy/run.md
+++ b/content/features/proxy/run.md
@@ -5,7 +5,7 @@ weight = 40
 
 This page is about running Memcached as a proxy for other Memcached servers.
 
-For a general overview of the proxy, see [Proxy]({{<legacy_proxy_base_path>}}). For a hands-on tutorial that guides you through compiling and running the proxy with a simple configuration, see [Built-in Proxy Quickstart]({{<proxy_base_path>}}quickstart).
+For a general overview of the proxy, see [Built-in proxy]({{<proxy_base_path>}}). For a hands-on tutorial that guides you through compiling and running the proxy with a simple configuration, see [Built-in Proxy Quickstart]({{<proxy_base_path>}}quickstart).
 
 ## Before you begin {#prereqs}
 

--- a/content/features/proxy/settings-reference.md
+++ b/content/features/proxy/settings-reference.md
@@ -1,6 +1,6 @@
 +++
 title = 'Proxy settings reference'
-weight = 101
+weight = 110
 +++
 
 This page is a reference for the settings you can optionally define to fine-tune the behavior of the Memcached built-in proxy. For a guide to applying these settings, see [Adjust proxy settings]({{<proxy_base_path>}}configure#settings).


### PR DESCRIPTION
This work includes:

* Trimming information from the legacy docs page that is now handled by newer pages
* Splitting the FAQ into its own page
* Adding weights and introductions to legacy pages so that they're more part of the new proxy docs flow