### PR TITLE
Fix example response for stale metaset

### DIFF
--- a/content/protocols/meta.md
+++ b/content/protocols/meta.md
@@ -267,7 +267,7 @@ request:
  ms foo S3 T360 C777 I\r\n
  new\r\n
 response:
- ST\r\n
+ HD\r\n
 ```
 
 The next metaget will continue to see the item as stale, with its previous


### PR DESCRIPTION
From some quick testing this seems to yield `HD` not `ST`:
```
$ printf 'mg foo t c f v\r\n' | nc -N 127.0.0.1 11213
VA 3 t3572 c21 f0
w4t
$ printf 'ms foo 3 T3600 C20 I\r\nw5t\r\n' | nc -N 127.0.0.1 11213
HD
$ printf 'mg foo t c f v\r\n' | nc -N 127.0.0.1 11213
VA 3 t3549 c22 f0 X W
w5t
```

protocol.txt also doesn't mention an `ST` response for metasets.